### PR TITLE
BFF Browser Extension Fix

### DIFF
--- a/public/wms.js
+++ b/public/wms.js
@@ -421,6 +421,14 @@ $3pl.pageMods.setup.smallParcelPackAndShip= async ()=>{
     // scanBoxOG.hidden=true
 
 
+    const inputEvent = new Event('input', {
+        bubbles: true,
+        cancelable: true,
+      });
+
+      scanBoxOG.style.display = "none";
+
+
     scanBox.addEventListener("keydown", (e)=>{
 
         // if the Enter key is pressed, copy the value from the scanBox
@@ -521,6 +529,10 @@ $3pl.pageMods.setup.smallParcelPackAndShip= async ()=>{
         }
 
         scanBoxOG.value = scanBox.value || ""
+       
+        scanBoxOG.setAttribute('value', scanBoxOG.value);
+
+        scanBoxOG.dispatchEvent(inputEvent);
     }
 
     /*


### PR DESCRIPTION
Fix Explanation
For properly setting scanBox value in scanBoxOG field. Created an Event object, setting its properties, and dispatching it to the textbox element as depicted below.
const inputEvent = new Event('input', {
 bubbles: true,
 cancelable: true,
 });
The code is creating a new instance of the Event object in JavaScript. This object represents an event which takes place in the DOM (Document Object Model), such as a user clicking an element, a page loading, or an input field receiving input. The Event constructor takes two arguments: the type of the event, and an optional dictionary of settings. In this case, the type of the event is 'input', which represents an event that is fired when the value of an <input>, <select>, or <textarea> element has been altered. The settings dictionary has two properties: bubbles and cancelable.
- bubbles: true means that the event will propagate up through the DOM tree. When an event bubbles, it will start from the element that triggered it, then move up to that element's parent, then the parent's parent, and so on, until it reaches the root of the document. This is useful for handling events at a higher level in the document, especially if those events are happening on dynamic elements.
- cancelable: true means that the event's default action can be prevented. For an 'input' event, the default action is the input being received by the element. If an event listener calls event.preventDefault() on a cancelable event, that default action will not occur. This Event object can be dispatched on a target element using the dispatchEvent method, which will trigger event listeners for the specified event type on the target element as depicted below. scanBoxOG.value = scanBox.value || ""
scanBoxOG.setAttribute('value', scanBoxOG.value);
scanBoxOG.dispatchEvent(inputEvent);
For hiding Original scanBox used the following code scanBoxOG.style.display = "none"